### PR TITLE
correct default image tag to match published image

### DIFF
--- a/charts/capsule-proxy/templates/_helpers.tpl
+++ b/charts/capsule-proxy/templates/_helpers.tpl
@@ -60,3 +60,10 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create the fully-qualified Docker image to use
+*/}}
+{{- define "capsule-proxy.fullyQualifiedDockerImage" -}}
+{{- printf "%s:%s" .Values.image.repository ( .Values.image.tag | default (printf "v%s" .Chart.AppVersion) ) -}}
+{{- end }}

--- a/charts/capsule-proxy/templates/deployment.yaml
+++ b/charts/capsule-proxy/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
+          image: {{ include "capsule-proxy.fullyQualifiedDockerImage" . }}
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - /capsule-proxy

--- a/charts/capsule-proxy/templates/deployment.yaml
+++ b/charts/capsule-proxy/templates/deployment.yaml
@@ -38,7 +38,7 @@ spec:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
-          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           command:
             - /capsule-proxy


### PR DESCRIPTION
The image tag defaults to `appVersion` which is currently `0.0.5`. However, the image is actually tagged `v0.0.5`.