### PR TITLE
Using kubeconfig to access the kubernetes api

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,38 @@ You can find more detailed documentation [here](https://github.com/clastix/capsu
 
 ## Contributions
 This is an open source software relased with Apache2 [license](./LICENSE). Feel free to open issues and pull requests. You're welcome!
+
+
+## How to: run locally for test and debug
+
+This guide helps new contributors to locally debug in _out or cluster_ mode the project.
+
+1. You need to run a kind cluster and find the endpoint port of `kind-control-plane` using `docker ps`:
+
+```bash
+❯ docker ps
+CONTAINER ID   IMAGE                  COMMAND                  CREATED          STATUS          PORTS                       NAMES
+88432e392adb   kindest/node:v1.20.2   "/usr/local/bin/entr…"   32 seconds ago   Up 28 seconds   127.0.0.1:64582->6443/tcp   kind-control-plane
+```
+
+2. You need to generate tsl cert keys for localhost, you can use [mkcert](https://github.com/FiloSottile/mkcert):
+
+```bash
+> cd /tmp
+> mkcert localhost
+> ls
+localhost-key.pem localhost.pem
+```
+
+3. Run the proxy with the following options
+
+```bash
+go run main.go --ssl-cert-path=/tmp/localhost.pem --ssl-key-path=/tmp/localhost-key.pem --k8s-control-plane-url=https://localhost:<KIND PORT> --enable-ssl=true --kubeconfig=<YOUR KUBERNETES CONFIGURATION FILE>
+```
+
+5. Edit the KUBECONFIG file (you should make a copy and work on it) as following:
+- Find the section of your cluster
+- replace the server path with `https://127.0.0.1:9001`
+- replace the certificate-authority-data path with the content of your rootCA.pem file. (if you use mkcert, you'll find with `cat "$(mkcert -CAROOT)/rootCA.pem"|base64|tr -d '\n'`)
+
+6. Now you should be able to run kubectl using the proxy!

--- a/internal/options/listener.go
+++ b/internal/options/listener.go
@@ -9,6 +9,6 @@ type ListenerOpts interface {
 	KubernetesControlPlaneUrl() *url.URL
 	UserGroupName() string
 	PreferredUsernameClaim() string
-	ReverseProxyTransport() *http.Transport
+	ReverseProxyTransport() (*http.Transport, error)
 	BearerToken() string
 }

--- a/internal/webserver/webserver.go
+++ b/internal/webserver/webserver.go
@@ -35,7 +35,12 @@ var (
 func NewKubeFilter(opts options.ListenerOpts, srv options.ServerOptions) (Filter, error) {
 	reverseProxy := httputil.NewSingleHostReverseProxy(opts.KubernetesControlPlaneUrl())
 	reverseProxy.FlushInterval = time.Millisecond * 100
-	reverseProxy.Transport = opts.ReverseProxyTransport()
+
+	reverseProxyTransport, err := opts.ReverseProxyTransport()
+	if err != nil {
+		return nil, err
+	}
+	reverseProxy.Transport = reverseProxyTransport
 
 	return &kubeFilter{
 		capsuleUserGroup:   opts.UserGroupName(),

--- a/main.go
+++ b/main.go
@@ -34,7 +34,7 @@ func main() {
 	var mgr ctrl.Manager
 
 	listeningPort := flag.Uint("listening-port", 9001, "HTTP port the proxy listens to (default: 9001)")
-	k8sControlPlaneUrl := flag.String("k8s-control-plane-url", "https://kubernetes.default.svc", "Kubernetes control plane URL (default: https://kubernetes.default.svc)")
+	k8sControlPlaneUrl := flag.String("k8s-control-plane-url", "", "Kubernetes control plane URL (DEPRECATED)")
 	capsuleUserGroup := flag.String("capsule-user-group", "capsule.clastix.io", "The Capsule User Group eligible to create Namespace for Tenant resources (default: capsule.clastix.io)")
 	usernameClaimField := flag.String("oidc-username-claim", "preferred_username", "The OIDC field name used to identify the user (default: preferred_username)")
 	bindSsl := flag.Bool("enable-ssl", false, "Enable the bind on HTTPS for secure communication (default: false)")
@@ -55,9 +55,13 @@ func main() {
 	log.Info("---")
 	log.Info(fmt.Sprintf("Manager listening on port %d", *listeningPort))
 	log.Info(fmt.Sprintf("Listening on HTTPS: %t", *bindSsl))
-	log.Info(fmt.Sprintf("Connecting to the Kubernete API Server listening on %s", *k8sControlPlaneUrl))
+	if *k8sControlPlaneUrl != "" {
+		log.Info(fmt.Sprintf("Connecting to the Kubernete API Server listening on %s", *k8sControlPlaneUrl))
+		log.Info(fmt.Sprintf("k8s-control-plane-url is DEPRECATED and won't be used in future release"))
+	}
 	log.Info(fmt.Sprintf("The selected Capsule User Group is %s", *capsuleUserGroup))
 	log.Info(fmt.Sprintf("The OIDC username selected is %s", *usernameClaimField))
+
 	log.Info("---")
 
 	log.Info("Creating the manager")


### PR DESCRIPTION
This PR Closes #67 and allow the connection to kubernetes using kubectl files.

## Changes

1. `k8s-control-plane-url` cmd option is Deprecated, now k8s api endpoint is obtained by kubeconfig, 
2. Authentication to k8s is done using certificates from kubeconfig. 
3. If running out of cluster you should provide the kubeconfig file using `--kubeconfig` cmd option!

## Usage

```bash
go run main.go --ssl-cert-path=/tmp/localhost.pem --ssl-key-path=/tmp/localhost-key.pem  --kubeconfig=./config.kub --enable-ssl=true
```

## Tests

I've manually tested with kind and I'm able to get nemespaces kubernetes api both out of cluster and in cluster.
In cluster it is using the TLS configuration provided by kubernetes automatically!

@prometherion when tests are ready we should run this against automated tests before merging.

@MaxFedotov  @bsctl any feedback?

Thanks to @davideimola for helping!

