### PR TITLE
e2e test using kubectl

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,13 @@ e2e/%: docker-build
 	# fake kubeconfig
 	cd hack \
 		&& curl -s https://raw.githubusercontent.com/clastix/capsule/master/hack/create-user.sh | bash -s -- alice oil \
-		&& curl -s https://raw.githubusercontent.com/clastix/capsule/master/hack/create-user.sh | bash -s -- bob gas
+		&& mv alice-oil.kubeconfig alice.kubeconfig \
+		&& KUBECONFIG=alice.kubeconfig kubectl config set clusters.kind-capsule.certificate-authority-data $$(cat ~/.local/share/mkcert/rootCA.pem | base64 |tr -d '\n') \
+		&& KUBECONFIG=alice.kubeconfig kubectl config set clusters.kind-capsule.server https://127.0.0.1:9001 \
+		&& curl -s https://raw.githubusercontent.com/clastix/capsule/master/hack/create-user.sh | bash -s -- bob gas \
+		&& mv bob-gas.kubeconfig bob.kubeconfig \
+		&& KUBECONFIG=bob.kubeconfig kubectl config set clusters.kind-capsule.certificate-authority-data $$(cat ~/.local/share/mkcert/rootCA.pem | base64 |tr -d '\n') \
+		&& KUBECONFIG=bob.kubeconfig kubectl config set clusters.kind-capsule.server https://127.0.0.1:9001
 	# capsule-proxy installation
 	kind load docker-image --name capsule --nodes capsule-control-plane quay.io/clastix/capsule-proxy:latest
 	helm upgrade --install capsule-proxy ./charts/capsule-proxy -n capsule-system \

--- a/Makefile
+++ b/Makefile
@@ -34,4 +34,9 @@ e2e/%: docker-build
 		--set "service.type=NodePort" \
 		--set "service.nodePort=" \
 		--set "hostNetwork=true"
+	# kubectl RBAC fix
+	kubectl create clusterrole capsule-selfsubjectaccessreviews --verb=create --resource=selfsubjectaccessreviews.authorization.k8s.io
+	kubectl create clusterrole capsule-apis --verb="get" --non-resource-url="/api/*" --non-resource-url="/api" --non-resource-url="/apis/*" --non-resource-url="/apis" --non-resource-url="/version"
+	kubectl create clusterrolebinding capsule:selfsubjectaccessreviews --clusterrole=capsule-selfsubjectaccessreviews --group=capsule.clastix.io
+	kubectl create clusterrolebinding capsule:apis --clusterrole=capsule-apis --group=capsule.clastix.io
 	./e2e/run.bash

--- a/e2e/run.bash
+++ b/e2e/run.bash
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -eo pipefail
 
+export HACK_DIR="$(git rev-parse --show-toplevel)/hack"
+
 echo ">>> Waiting for capsule-proxy pod to be ready for accepting requests"
 kubectl --namespace capsule-system wait --for=condition=ready --timeout=320s pod -l app.kubernetes.io/instance=capsule-proxy
 echo ">>> Waiting for capsule pod to be ready for accepting requests"

--- a/e2e/tests/00_namespaces_list.bats
+++ b/e2e/tests/00_namespaces_list.bats
@@ -19,7 +19,12 @@ teardown() {
   delete_tenant gas
 }
 
-@test "Checking namespaces count" {
-  poll_until_equals "Namespaces count belonging to gas" "1" "curl -s --cacert ~/.local/share/mkcert/rootCA.pem --cert ./hack/bob-gas.crt --key ./hack/bob-gas.key 'https://127.0.0.1:9001/api/v1/namespaces' | jq .items | jq length" 3 5
-  poll_until_equals "Namespaces count belonging to oil" "3" "curl -s --cacert ~/.local/share/mkcert/rootCA.pem --cert ./hack/alice-oil.crt --key ./hack/alice-oil.key 'https://127.0.0.1:9001/api/v1/namespaces' | jq .items | jq length" 3 5
+@test "Checking namespaces count via kubectl" {
+  local gas="namespace/gas-qa"
+  poll_until_equals "Checking kubectl output for gas" "$gas" "KUBECONFIG=${HACK_DIR}/bob.kubeconfig kubectl get namespaces --output=name" 3 5
+
+  local oil="namespace/oil-dev
+namespace/oil-production
+namespace/oil-staging"
+  poll_until_equals "Checking kubectl output for oil" "$oil" "KUBECONFIG=${HACK_DIR}/alice.kubeconfig kubectl get namespaces --output=name" 3 5
 }

--- a/e2e/tests/01_namespaces_filtering.bats
+++ b/e2e/tests/01_namespaces_filtering.bats
@@ -19,12 +19,14 @@ teardown() {
   delete_tenant bizz
 }
 
-@test "Listing with labelSelector" {
-  poll_until_equals "non-filtered Namespaces count matching" "2" "curl -s --cacert ~/.local/share/mkcert/rootCA.pem --cert ./hack/alice-oil.crt --key ./hack/alice-oil.key 'https://127.0.0.1:9001/api/v1/namespaces' | jq .items | jq length" 3 5
+@test "Listing with labelSelector via kubectl" {
+  local list="namespace/bizz-filter
+namespace/foo-filter"
+  poll_until_equals "list of all Namespaces of different tenants" "$list" "KUBECONFIG=${HACK_DIR}/alice.kubeconfig kubectl get namespaces --output=name" 3 5
 
-  poll_until_equals "filtered Namespace count matching the foo=bar filter" "1" "curl -s --cacert ~/.local/share/mkcert/rootCA.pem --cert ./hack/alice-oil.crt --key ./hack/alice-oil.key 'https://127.0.0.1:9001/api/v1/namespaces?labelSelector=foo=bar' | jq .items | jq length" 3 5
-  poll_until_equals "filtered Namespace name matching foo-filter" "foo-filter" "curl -s --cacert ~/.local/share/mkcert/rootCA.pem --cert ./hack/alice-oil.crt --key ./hack/alice-oil.key 'https://127.0.0.1:9001/api/v1/namespaces?labelSelector=foo=bar' | jq -r '.items[0].metadata.name'" 3 5
+  local list="namespace/foo-filter"
+  poll_until_equals "selecting foo-filter Namespace" "$list" "KUBECONFIG=${HACK_DIR}/alice.kubeconfig kubectl get namespaces --output=name --selector foo=bar" 3 5
 
-  poll_until_equals "filtered Namespace count matching the bizz=buzz filter" "1" "curl -s --cacert ~/.local/share/mkcert/rootCA.pem --cert ./hack/alice-oil.crt --key ./hack/alice-oil.key 'https://127.0.0.1:9001/api/v1/namespaces?labelSelector=bizz=buzz' | jq .items | jq length" 3 5
-  poll_until_equals "filtered Namespace name matching bizz-filter" "bizz-filter" "curl -s --cacert ~/.local/share/mkcert/rootCA.pem --cert ./hack/alice-oil.crt --key ./hack/alice-oil.key 'https://127.0.0.1:9001/api/v1/namespaces?labelSelector=bizz=buzz' | jq -r '.items[0].metadata.name'" 3 5
+  local list="namespace/bizz-filter"
+  poll_until_equals "selecting bizz-filter Namespace" "$list" "KUBECONFIG=${HACK_DIR}/alice.kubeconfig kubectl get namespaces --output=name --selector bizz=buzz" 3 5
 }

--- a/e2e/tests/02_node_listing.bats
+++ b/e2e/tests/02_node_listing.bats
@@ -22,7 +22,9 @@ teardown() {
   kubectl label node capsule-control-plane capsule.clastix.io/tenant-
 }
 
-@test "Nodes listing allowed" {
-  poll_until_equals "filtered Node count matching on BYOD scenario" "1" "curl -s --cacert ~/.local/share/mkcert/rootCA.pem --cert ./hack/alice-oil.crt --key ./hack/alice-oil.key 'https://127.0.0.1:9001/api/v1/nodes' | jq .items | jq length" 3 5
-  poll_until_equals "filtered Node count matching on shared scenario" "0" "curl -s --cacert ~/.local/share/mkcert/rootCA.pem --cert ./hack/bob-gas.crt --key ./hack/bob-gas.key 'https://127.0.0.1:9001/api/v1/nodes' | jq .items | jq length" 3 5
+@test "Nodes listing allowed via kubectl" {
+  poll_until_equals "filtered Node on shared scenario" "" "KUBECONFIG=${HACK_DIR}/bob.kubeconfig kubectl get node --output=name" 3 5
+
+  local list="node/capsule-control-plane"
+  poll_until_equals "filtered Node on BYOD scenario" "$list" "KUBECONFIG=${HACK_DIR}/alice.kubeconfig kubectl get node --output=name" 3 5
 }

--- a/e2e/tests/03_root.bats
+++ b/e2e/tests/03_root.bats
@@ -1,0 +1,13 @@
+#!/usr/bin/env bats
+
+load "$BATS_TEST_DIRNAME/../libs/poll.bash"
+
+@test "Checking kubectl api-resources" {
+  run sh -c "KUBECONFIG=${HACK_DIR}/alice.kubeconfig kubectl api-resources"
+  [ $status -eq 0 ]
+}
+
+@test "Checking kubectl version" {
+  run sh -c "KUBECONFIG=${HACK_DIR}/alice.kubeconfig kubectl version"
+  [ $status -eq 0 ]
+}

--- a/e2e/tests/04_namespace_managing.bats
+++ b/e2e/tests/04_namespace_managing.bats
@@ -1,0 +1,30 @@
+#!/usr/bin/env bats
+
+load "$BATS_TEST_DIRNAME/../libs/namespaces_utils.bash"
+load "$BATS_TEST_DIRNAME/../libs/poll.bash"
+load "$BATS_TEST_DIRNAME/../libs/tenants_utils.bash"
+
+setup() {
+  create_tenant oil alice
+  create_namespace alice oil-app
+}
+
+teardown() {
+  delete_tenant oil
+}
+
+@test "Managing a Deployment" {
+  run sh -c "KUBECONFIG=${HACK_DIR}/alice.kubeconfig kubectl --namespace oil-app create deployment --image redis:alpine my-cache"
+  [ $status -eq 0 ]
+
+  run sh -c "KUBECONFIG=${HACK_DIR}/alice.kubeconfig kubectl --namespace oil-app get deployment my-cache"
+  [ $status -eq 0 ]
+}
+
+@test "Managing a Service" {
+  run sh -c "KUBECONFIG=${HACK_DIR}/alice.kubeconfig kubectl --namespace oil-app create service clusterip my-svc --tcp=5678:8080"
+  [ $status -eq 0 ]
+
+  run sh -c "KUBECONFIG=${HACK_DIR}/alice.kubeconfig kubectl --namespace oil-app get service my-svc"
+  [ $status -eq 0 ]
+}


### PR DESCRIPTION
Partially addressing #64, with `kubectl` we should have fewer headaches since there is a built-in retry method and output management that helps the assertions.