### PR TITLE
Upgrading the Docker build target to Go 1.16

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.13 as builder
+FROM golang:1.16 as builder
 WORKDIR /workspace
 COPY go.mod go.mod
 COPY go.sum go.sum

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/clastix/capsule-proxy
 
-go 1.13
+go 1.16
 
 require (
 	github.com/clastix/capsule v0.0.4


### PR DESCRIPTION
Closes #75.