### PR TITLE
Switching over middleware to solve out-of-cluster mode

### DIFF
--- a/e2e/tests/05_denied_namespaces.bats
+++ b/e2e/tests/05_denied_namespaces.bats
@@ -1,0 +1,26 @@
+#!/usr/bin/env bats
+
+@test "Getting default namespace is denied" {
+  run sh -c "KUBECONFIG=${HACK_DIR}/alice.kubeconfig kubectl get namespace default"
+  [ $status -ne 0 ]
+  [ "${lines[0]}" = 'Error from server (Forbidden): namespaces "default" is forbidden: User "alice" cannot get resource "namespaces" in API group "" in the namespace "default"' ]
+}
+
+@test "Listing Pods on default namespace is denied" {
+  run sh -c "KUBECONFIG=${HACK_DIR}/alice.kubeconfig kubectl --namespace default get pods"
+  [ $status -ne 0 ]
+  [ "${lines[0]}" = 'Error from server (Forbidden): pods is forbidden: User "alice" cannot list resource "pods" in API group "" in the namespace "default"' ]
+}
+
+@test "Listing Services on default namespace is denied" {
+  run sh -c "KUBECONFIG=${HACK_DIR}/alice.kubeconfig kubectl --namespace default get services"
+  [ $status -ne 0 ]
+  [ "${lines[0]}" = 'Error from server (Forbidden): services is forbidden: User "alice" cannot list resource "services" in API group "" in the namespace "default"' ]
+}
+
+@test "Listing ConfigMaps on default namespace is denied" {
+  run sh -c "KUBECONFIG=${HACK_DIR}/alice.kubeconfig kubectl --namespace default get configmaps"
+  [ $status -ne 0 ]
+  [ "${lines[0]}" = 'Error from server (Forbidden): configmaps is forbidden: User "alice" cannot list resource "configmaps" in API group "" in the namespace "default"' ]
+}
+


### PR DESCRIPTION
Closes #74, and closes #65 as well.

Along with the additional test case checking for the expected failure due to missing RoleBinding for the _default_ namespace, this refactoring solves the out-of-cluster mode, as well implementing the middleware logic that skips User-Authentication for the decorated requests (`/api/v1/namespaces` and `/api/v1/nodes`).

A prerequisite to solving #74 was implementing #65, although already assigned to @ludusrusso: having a review from you would be great, as well co-authoring the commits.