### PR TITLE
Makefile support OS X. Additional tests for node. Remove unused request interfaces

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,10 @@
+OS := $(shell uname)
+ifeq ($(OS),Darwin)
+	ROOTCA=~/Library/Application\ Support/mkcert/rootCA.pem
+else
+	ROOTCA=~/.local/share/mkcert/rootCA.pem
+endif
+
 dlv-build:
 	docker build . --build-arg "GCFLAGS=all=-N -l" --tag quay.io/clastix/capsule-proxy:dlv --target dlv
 
@@ -21,11 +28,11 @@ e2e/%: docker-build
 	cd hack \
 		&& curl -s https://raw.githubusercontent.com/clastix/capsule/master/hack/create-user.sh | bash -s -- alice oil \
 		&& mv alice-oil.kubeconfig alice.kubeconfig \
-		&& KUBECONFIG=alice.kubeconfig kubectl config set clusters.kind-capsule.certificate-authority-data $$(cat ~/.local/share/mkcert/rootCA.pem | base64 |tr -d '\n') \
+		&& KUBECONFIG=alice.kubeconfig kubectl config set clusters.kind-capsule.certificate-authority-data $$(cat $(ROOTCA) | base64 |tr -d '\n') \
 		&& KUBECONFIG=alice.kubeconfig kubectl config set clusters.kind-capsule.server https://127.0.0.1:9001 \
 		&& curl -s https://raw.githubusercontent.com/clastix/capsule/master/hack/create-user.sh | bash -s -- bob gas \
 		&& mv bob-gas.kubeconfig bob.kubeconfig \
-		&& KUBECONFIG=bob.kubeconfig kubectl config set clusters.kind-capsule.certificate-authority-data $$(cat ~/.local/share/mkcert/rootCA.pem | base64 |tr -d '\n') \
+		&& KUBECONFIG=bob.kubeconfig kubectl config set clusters.kind-capsule.certificate-authority-data $$(cat $(ROOTCA) | base64 |tr -d '\n') \
 		&& KUBECONFIG=bob.kubeconfig kubectl config set clusters.kind-capsule.server https://127.0.0.1:9001
 	# capsule-proxy installation
 	kind load docker-image --name capsule --nodes capsule-control-plane quay.io/clastix/capsule-proxy:latest

--- a/e2e/run.bash
+++ b/e2e/run.bash
@@ -9,4 +9,4 @@ echo ">>> Waiting for capsule pod to be ready for accepting requests"
 kubectl --namespace capsule-system wait --for=condition=ready --timeout=320s pod -l app.kubernetes.io/instance=capsule
 
 echo ">>> Starting test suite"
-bats -t "$(git rev-parse --show-toplevel)"/e2e/tests/06_*
+bats -t "$(git rev-parse --show-toplevel)"/e2e/tests/*

--- a/e2e/run.bash
+++ b/e2e/run.bash
@@ -9,4 +9,4 @@ echo ">>> Waiting for capsule pod to be ready for accepting requests"
 kubectl --namespace capsule-system wait --for=condition=ready --timeout=320s pod -l app.kubernetes.io/instance=capsule
 
 echo ">>> Starting test suite"
-bats -t "$(git rev-parse --show-toplevel)"/e2e/tests/*
+bats -t "$(git rev-parse --show-toplevel)"/e2e/tests/06_*

--- a/e2e/tests/06_node_get.bats
+++ b/e2e/tests/06_node_get.bats
@@ -15,6 +15,8 @@ teardown() {
 
   kubectl label node capsule-control-plane capsule.clastix.io/tenant-
   kubectl label node capsule-control-plane capsule.clastix.io/test-
+  kubectl uncordon capsule-control-plane
+  kubectl taint nodes capsule-control-plane key1=value1:NoSchedule-
 }
 
 @test "Nodes retrieval via kubectl" {

--- a/internal/request/http.go
+++ b/internal/request/http.go
@@ -25,18 +25,6 @@ func NewHttp(request *h.Request, usernameClaimField string) Request {
 	return &http{Request: request, usernameClaimField: usernameClaimField}
 }
 
-func (h http) IsNodeListing() (ok bool) {
-	ok = h.URL.Path == "/api/v1/nodes"
-	ok = (h.Method == "GET" || h.isWatchEndpoint()) && ok
-	return
-}
-
-func (h http) IsNamespaceListing() (ok bool) {
-	ok = h.URL.Path == "/api/v1/namespaces"
-	ok = (h.Method == "GET" || h.isWatchEndpoint()) && ok
-	return
-}
-
 func (h http) GetUserAndGroups() (username string, groups []string, err error) {
 	switch h.getAuthType() {
 	case certificateBased:

--- a/internal/request/request.go
+++ b/internal/request/request.go
@@ -2,6 +2,4 @@ package request
 
 type Request interface {
 	GetUserAndGroups() (string, []string, error)
-	IsNamespaceListing() (ok bool)
-	IsNodeListing() (ok bool)
 }


### PR DESCRIPTION
Hi @prometherion, 

Thanks a lot for your work :)
When I've tried to run `make e2e` on OS X found an issue with mkcert rootCA location - it is different then on Linux, so I've fixed it.
Also I've added tests for cordon\taint (although they are just the same editing node spec, but in case something changes in future I think it is a good idea to have them)
And I removed unused interface methods from request