### PR TITLE
Use multiple Impersonate-Group headers

### DIFF
--- a/internal/webserver/webserver.go
+++ b/internal/webserver/webserver.go
@@ -178,7 +178,10 @@ func (n kubeFilter) impersonateHandler(writer http.ResponseWriter, request *http
 		}
 
 		request.Header.Add("Impersonate-User", username)
-		request.Header.Add("Impersonate-Group", strings.Join(groups, ","))
+
+		for _, group := range groups {
+			request.Header.Add("Impersonate-Group", group)
+		}
 	}
 }
 


### PR DESCRIPTION
The kubernetes documentation specifies group information is set in multiple headers, not a single header with comma separation. https://kubernetes.io/docs/reference/access-authn-authz/authentication/#user-impersonation

This change replaces the string.Join with a simple loop over the groups to implement this change.