### PR TITLE
Ignoring certain user groups from filtering

### DIFF
--- a/charts/capsule-proxy/Chart.yaml
+++ b/charts/capsule-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
 appVersion: 0.1.0
-description: A Helm chart for Kubernetes
+description: Helm Chart for Capsule Proxy, addon for Capsule, the multi-tenant Operator
 name: capsule-proxy
 type: application
 version: 0.1.4

--- a/charts/capsule-proxy/README.md
+++ b/charts/capsule-proxy/README.md
@@ -68,6 +68,7 @@ Parameter | Description | Default
 `options.logLevel` | Set the log verbosity of the capsule-proxy with a value from 1 to 10.| `4`
 `options.k8sControlPlaneUrl` | Set the URL of kubernetes control plane. | `https://kubernetes.default.svc`
 `options.capsuleUserGroups` | Override the Capsule user group | `[ "capsule.clastix.io" ]`
+`options.ignoredUserGroups` | Define which groups must be ignored while proxying requests | `[ ]`
 `options.oidcUsernameClaim` | Override the OIDC field name used to identify the user | `preferred_username`
 `options.enableSSL` | Specify if capsule-proxy will use SSL | `false`
 `options.SSLDirectory` | Set the directory, where SSL certificate and keyfile will be located | `/opt/capsule-proxy`

--- a/charts/capsule-proxy/templates/daemonset.yaml
+++ b/charts/capsule-proxy/templates/daemonset.yaml
@@ -50,6 +50,9 @@ spec:
         {{- range .Values.options.capsuleUserGroups }}
         - --capsule-user-group={{ . }}
         {{- end}}
+        {{- range .Values.options.ignoredUserGroups }}
+        - --ignored-user-group={{ . }}
+        {{- end}}
         - --zap-log-level={{ .Values.options.logLevel }}
         - --enable-ssl={{ .Values.options.enableSSL }}
         - --oidc-username-claim={{ .Values.options.oidcUsernameClaim }}

--- a/charts/capsule-proxy/templates/deployment.yaml
+++ b/charts/capsule-proxy/templates/deployment.yaml
@@ -48,6 +48,9 @@ spec:
         - --listening-port={{ .Values.options.listeningPort }}
         {{- range .Values.options.capsuleUserGroups }}
         - --capsule-user-group={{ . }}
+        {{- end }}
+        {{- range .Values.options.ignoredUserGroups }}
+        - --ignored-user-group={{ . }}
         {{- end}}
         - --zap-log-level={{ .Values.options.logLevel }}
         - --enable-ssl={{ .Values.options.enableSSL }}

--- a/charts/capsule-proxy/values.yaml
+++ b/charts/capsule-proxy/values.yaml
@@ -13,6 +13,7 @@ options:
   logLevel: '4'
   k8sControlPlaneUrl: https://kubernetes.default.svc
   capsuleUserGroups: ["capsule.clastix.io"]
+  ignoredUserGroups: []
   oidcUsernameClaim: preferred_username
   enableSSL: false
   SSLDirectory: /opt/capsule-proxy

--- a/go.mod
+++ b/go.mod
@@ -12,7 +12,7 @@ require (
 	github.com/spf13/pflag v1.0.5
 	go.uber.org/zap v1.18.1
 	k8s.io/api v0.22.0
-	k8s.io/apimachinery v0.22.0
+	k8s.io/apimachinery v0.22.1
 	k8s.io/client-go v0.22.0
 	sigs.k8s.io/controller-runtime v0.9.5
 )

--- a/go.sum
+++ b/go.sum
@@ -810,6 +810,8 @@ k8s.io/apiextensions-apiserver v0.22.0/go.mod h1:+9w/QQC/lwH2qTbpqndXXjwBgidlSmy
 k8s.io/apimachinery v0.21.3/go.mod h1:H/IM+5vH9kZRNJ4l3x/fXP/5bOPJaVP/guptnZPeCFI=
 k8s.io/apimachinery v0.22.0 h1:CqH/BdNAzZl+sr3tc0D3VsK3u6ARVSo3GWyLmfIjbP0=
 k8s.io/apimachinery v0.22.0/go.mod h1:O3oNtNadZdeOMxHFVxOreoznohCpy0z6mocxbZr7oJ0=
+k8s.io/apimachinery v0.22.1 h1:DTARnyzmdHMz7bFWFDDm22AM4pLWTQECMpRTFu2d2OM=
+k8s.io/apimachinery v0.22.1/go.mod h1:O3oNtNadZdeOMxHFVxOreoznohCpy0z6mocxbZr7oJ0=
 k8s.io/apiserver v0.21.3/go.mod h1:eDPWlZG6/cCCMj/JBcEpDoK+I+6i3r9GsChYBHSbAzU=
 k8s.io/apiserver v0.22.0/go.mod h1:04kaIEzIQrTGJ5syLppQWvpkLJXQtJECHmae+ZGc/nc=
 k8s.io/client-go v0.21.3/go.mod h1:+VPhCgTsaFmGILxR/7E1N0S+ryO010QBeNCv5JwRGYU=

--- a/internal/options/kube.go
+++ b/internal/options/kube.go
@@ -17,23 +17,25 @@ import (
 )
 
 type kubeOpts struct {
-	url        url.URL
-	groupNames []string
-	claimName  string
-	config     *rest.Config
+	url           url.URL
+	groupNames    []string
+	ignoredGroups []string
+	claimName     string
+	config        *rest.Config
 }
 
-func NewKube(groupNames []string, claimName string, config *rest.Config) (ListenerOpts, error) {
+func NewKube(groupNames, ignoredGroups []string, claimName string, config *rest.Config) (ListenerOpts, error) {
 	u, err := url.Parse(config.Host)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create Kubernetes Options due to failed URL parsing: %w", err)
 	}
 
 	return &kubeOpts{
-		url:        *u,
-		groupNames: groupNames,
-		claimName:  claimName,
-		config:     config,
+		url:           *u,
+		groupNames:    groupNames,
+		ignoredGroups: ignoredGroups,
+		claimName:     claimName,
+		config:        config,
 	}, nil
 }
 
@@ -47,6 +49,10 @@ func (k kubeOpts) KubernetesControlPlaneURL() *url.URL {
 
 func (k kubeOpts) UserGroupNames() []string {
 	return k.groupNames
+}
+
+func (k kubeOpts) IgnoredGroupNames() []string {
+	return k.ignoredGroups
 }
 
 func (k kubeOpts) PreferredUsernameClaim() string {

--- a/internal/options/listener.go
+++ b/internal/options/listener.go
@@ -11,6 +11,7 @@ import (
 type ListenerOpts interface {
 	KubernetesControlPlaneURL() *url.URL
 	UserGroupNames() []string
+	IgnoredGroupNames() []string
 	PreferredUsernameClaim() string
 	ReverseProxyTransport() (*http.Transport, error)
 	BearerToken() string

--- a/internal/webserver/webserver.go
+++ b/internal/webserver/webserver.go
@@ -52,7 +52,7 @@ func NewKubeFilter(opts options.ListenerOpts, srv options.ServerOptions) (Filter
 	reverseProxy.Transport = reverseProxyTransport
 
 	return &kubeFilter{
-		capsuleUserGroups:  opts.UserGroupNames(),
+		capsuleUserGroups:  sets.NewString(opts.UserGroupNames()...),
 		ignoredUserGroups:  sets.NewString(opts.IgnoredGroupNames()...),
 		reverseProxy:       reverseProxy,
 		bearerToken:        opts.BearerToken(),
@@ -63,7 +63,7 @@ func NewKubeFilter(opts options.ListenerOpts, srv options.ServerOptions) (Filter
 }
 
 type kubeFilter struct {
-	capsuleUserGroups  []string
+	capsuleUserGroups  sets.String
 	ignoredUserGroups  sets.String
 	reverseProxy       *httputil.ReverseProxy
 	client             client.Client

--- a/main.go
+++ b/main.go
@@ -37,6 +37,8 @@ func main() {
 
 	var capsuleUserGroups []string
 
+	var ignoredUserGroups []string
+
 	var listeningPort uint
 
 	var usernameClaimField string
@@ -48,6 +50,7 @@ func main() {
 	var keyPath string
 
 	flag.StringSliceVar(&capsuleUserGroups, "capsule-user-group", []string{capsulev1beta1.GroupVersion.Group}, "Names of the groups for capsule users")
+	flag.StringSliceVar(&ignoredUserGroups, "ignored-user-group", []string{}, "Names of the groups which requests must be ignored and proxy-passed to the upstream server")
 	flag.UintVar(&listeningPort, "listening-port", 9001, "HTTP port the proxy listens to (default: 9001)")
 	flag.StringVar(&usernameClaimField, "oidc-username-claim", "preferred_username", "The OIDC field name used to identify the user (default: preferred_username)")
 	flag.BoolVar(&bindSsl, "enable-ssl", false, "Enable the bind on HTTPS for secure communication (default: false)")
@@ -72,7 +75,8 @@ func main() {
 	log.Info(fmt.Sprintf("Manager listening on port %d", listeningPort))
 	log.Info(fmt.Sprintf("Listening on HTTPS: %t", bindSsl))
 
-	log.Info(fmt.Sprintf("The selected Capsule User Group is %v", capsuleUserGroups))
+	log.Info(fmt.Sprintf("The selected Capsule User Groups are %v", capsuleUserGroups))
+	log.Info(fmt.Sprintf("The ignored User Groups are %v", ignoredUserGroups))
 	log.Info(fmt.Sprintf("The OIDC username selected is %s", usernameClaimField))
 	log.Info("---")
 	log.Info("Creating the manager")
@@ -101,7 +105,7 @@ func main() {
 
 	var listenerOpts options.ListenerOpts
 
-	if listenerOpts, err = options.NewKube(capsuleUserGroups, usernameClaimField, ctrl.GetConfigOrDie()); err != nil {
+	if listenerOpts, err = options.NewKube(capsuleUserGroups, ignoredUserGroups, usernameClaimField, ctrl.GetConfigOrDie()); err != nil {
 		log.Error(err, "cannot create Kubernetes options")
 		os.Exit(1)
 	}


### PR DESCRIPTION
Closes #119.

Adding a new slice CLI flag named `--ignored-user-group` an administrator can set which groups must be ignored from filtering, executing just the impersonate handler and bypassing all the underlying handlers.