### PR TITLE
Reading CapsuleConfiguration CR for Capsule user groups retrieval.

### DIFF
--- a/charts/capsule-proxy/README.md
+++ b/charts/capsule-proxy/README.md
@@ -67,7 +67,7 @@ Parameter | Description | Default
 `options.listeningPort` | Set the listening port of the capsule-proxy.| `9001`
 `options.logLevel` | Set the log verbosity of the capsule-proxy with a value from 1 to 10.| `4`
 `options.k8sControlPlaneUrl` | Set the URL of kubernetes control plane. | `https://kubernetes.default.svc`
-`options.capsuleUserGroups` | Override the Capsule user group | `[ "capsule.clastix.io" ]`
+`options.capsuleConfigurationName` | Name of the CapsuleConfiguration custom resource used by Capsule, required to identify the user groups | `"default"`
 `options.ignoredUserGroups` | Define which groups must be ignored while proxying requests | `[ ]`
 `options.oidcUsernameClaim` | Override the OIDC field name used to identify the user | `preferred_username`
 `options.enableSSL` | Specify if capsule-proxy will use SSL | `false`

--- a/charts/capsule-proxy/templates/daemonset.yaml
+++ b/charts/capsule-proxy/templates/daemonset.yaml
@@ -47,9 +47,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
         - --listening-port={{ .Values.options.listeningPort }}
-        {{- range .Values.options.capsuleUserGroups }}
-        - --capsule-user-group={{ . }}
-        {{- end}}
+        - --capsule-configuration-name={{ .Values.options.capsuleConfigurationName }}
         {{- range .Values.options.ignoredUserGroups }}
         - --ignored-user-group={{ . }}
         {{- end}}

--- a/charts/capsule-proxy/templates/deployment.yaml
+++ b/charts/capsule-proxy/templates/deployment.yaml
@@ -46,9 +46,7 @@ spec:
         imagePullPolicy: {{ .Values.image.pullPolicy }}
         args:
         - --listening-port={{ .Values.options.listeningPort }}
-        {{- range .Values.options.capsuleUserGroups }}
-        - --capsule-user-group={{ . }}
-        {{- end }}
+        - --capsule-configuration-name={{ .Values.options.capsuleConfigurationName }}
         {{- range .Values.options.ignoredUserGroups }}
         - --ignored-user-group={{ . }}
         {{- end}}

--- a/charts/capsule-proxy/values.yaml
+++ b/charts/capsule-proxy/values.yaml
@@ -12,7 +12,7 @@ options:
   listeningPort: 9001
   logLevel: '4'
   k8sControlPlaneUrl: https://kubernetes.default.svc
-  capsuleUserGroups: ["capsule.clastix.io"]
+  capsuleConfigurationName: default
   ignoredUserGroups: []
   oidcUsernameClaim: preferred_username
   enableSSL: false

--- a/internal/controllers/capsule_configuration.go
+++ b/internal/controllers/capsule_configuration.go
@@ -1,0 +1,58 @@
+// Copyright 2020-2021 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package controllers
+
+import (
+	"context"
+
+	capsulev1alpha1 "github.com/clastix/capsule/api/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/sets"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/builder"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type CapsuleConfiguration struct {
+	client                      client.Client
+	CapsuleConfigurationName    string
+	DeprecatedCapsuleUserGroups []string
+}
+
+// nolint
+var CapsuleUserGroups sets.String
+
+func (c *CapsuleConfiguration) SetupWithManager(mgr ctrl.Manager) error {
+	if len(c.DeprecatedCapsuleUserGroups) > 0 {
+		CapsuleUserGroups = sets.NewString(c.DeprecatedCapsuleUserGroups...)
+
+		return nil
+	}
+
+	return ctrl.NewControllerManagedBy(mgr).
+		For(&capsulev1alpha1.CapsuleConfiguration{}, builder.WithPredicates(predicate.NewPredicateFuncs(func(object client.Object) bool {
+			return object.GetName() == c.CapsuleConfigurationName
+		}))).
+		Complete(c)
+}
+
+func (c *CapsuleConfiguration) Reconcile(ctx context.Context, request reconcile.Request) (reconcile.Result, error) {
+	capsuleConfig := &capsulev1alpha1.CapsuleConfiguration{}
+
+	if err := c.client.Get(ctx, types.NamespacedName{Name: request.Name}, capsuleConfig); err != nil {
+		panic(err)
+	}
+
+	CapsuleUserGroups = sets.NewString(capsuleConfig.Spec.UserGroups...)
+
+	return reconcile.Result{}, nil
+}
+
+func (c *CapsuleConfiguration) InjectClient(client client.Client) error {
+	c.client = client
+
+	return nil
+}

--- a/internal/options/kube.go
+++ b/internal/options/kube.go
@@ -18,13 +18,12 @@ import (
 
 type kubeOpts struct {
 	url           url.URL
-	groupNames    []string
 	ignoredGroups []string
 	claimName     string
 	config        *rest.Config
 }
 
-func NewKube(groupNames, ignoredGroups []string, claimName string, config *rest.Config) (ListenerOpts, error) {
+func NewKube(ignoredGroups []string, claimName string, config *rest.Config) (ListenerOpts, error) {
 	u, err := url.Parse(config.Host)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create Kubernetes Options due to failed URL parsing: %w", err)
@@ -32,7 +31,6 @@ func NewKube(groupNames, ignoredGroups []string, claimName string, config *rest.
 
 	return &kubeOpts{
 		url:           *u,
-		groupNames:    groupNames,
 		ignoredGroups: ignoredGroups,
 		claimName:     claimName,
 		config:        config,
@@ -45,10 +43,6 @@ func (k kubeOpts) BearerToken() string {
 
 func (k kubeOpts) KubernetesControlPlaneURL() *url.URL {
 	return &k.url
-}
-
-func (k kubeOpts) UserGroupNames() []string {
-	return k.groupNames
 }
 
 func (k kubeOpts) IgnoredGroupNames() []string {

--- a/internal/options/listener.go
+++ b/internal/options/listener.go
@@ -10,7 +10,6 @@ import (
 
 type ListenerOpts interface {
 	KubernetesControlPlaneURL() *url.URL
-	UserGroupNames() []string
 	IgnoredGroupNames() []string
 	PreferredUsernameClaim() string
 	ReverseProxyTransport() (*http.Transport, error)

--- a/internal/webserver/middleware/user_in_group.go
+++ b/internal/webserver/middleware/user_in_group.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/apimachinery/pkg/util/sets"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	"github.com/clastix/capsule-proxy/internal/controllers"
 	req "github.com/clastix/capsule-proxy/internal/request"
 )
 
@@ -38,7 +39,7 @@ func CheckUserInIgnoredGroupMiddleware(client client.Client, log logr.Logger, cl
 	}
 }
 
-func CheckUserInCapsuleGroupMiddleware(client client.Client, log logr.Logger, claim string, groupNames sets.String, impersonate func(http.ResponseWriter, *http.Request)) mux.MiddlewareFunc {
+func CheckUserInCapsuleGroupMiddleware(client client.Client, log logr.Logger, claim string, impersonate func(http.ResponseWriter, *http.Request)) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(writer http.ResponseWriter, request *http.Request) {
 			_, groups, err := req.NewHTTP(request, claim, client).GetUserAndGroups()
@@ -46,7 +47,7 @@ func CheckUserInCapsuleGroupMiddleware(client client.Client, log logr.Logger, cl
 				log.Error(err, "Cannot retrieve username and group from request")
 			}
 			for _, group := range groups {
-				if groupNames.Has(group) || group == "system:serviceaccounts" {
+				if controllers.CapsuleUserGroups.Has(group) || group == "system:serviceaccounts" {
 					next.ServeHTTP(writer, request)
 
 					return

--- a/internal/webserver/webserver.go
+++ b/internal/webserver/webserver.go
@@ -53,7 +53,6 @@ func NewKubeFilter(opts options.ListenerOpts, srv options.ServerOptions) (Filter
 	reverseProxy.Transport = reverseProxyTransport
 
 	return &kubeFilter{
-		capsuleUserGroups:  sets.NewString(opts.UserGroupNames()...),
 		ignoredUserGroups:  sets.NewString(opts.IgnoredGroupNames()...),
 		reverseProxy:       reverseProxy,
 		bearerToken:        opts.BearerToken(),
@@ -64,7 +63,6 @@ func NewKubeFilter(opts options.ListenerOpts, srv options.ServerOptions) (Filter
 }
 
 type kubeFilter struct {
-	capsuleUserGroups  sets.String
 	ignoredUserGroups  sets.String
 	reverseProxy       *httputil.ReverseProxy
 	client             client.Client
@@ -224,7 +222,7 @@ func (n kubeFilter) registerModules(root *mux.Router) {
 		sr.Use(
 			middleware.CheckJWTMiddleware(n.client, n.log),
 			middleware.CheckUserInIgnoredGroupMiddleware(n.client, n.log, n.usernameClaimField, n.ignoredUserGroups, n.impersonateHandler),
-			middleware.CheckUserInCapsuleGroupMiddleware(n.client, n.log, n.usernameClaimField, n.capsuleUserGroups, n.impersonateHandler),
+			middleware.CheckUserInCapsuleGroupMiddleware(n.client, n.log, n.usernameClaimField, n.impersonateHandler),
 		)
 		sr.HandleFunc("", func(writer http.ResponseWriter, request *http.Request) {
 			username, groups, _ := req.NewHTTP(request, n.usernameClaimField, n.client).GetUserAndGroups()


### PR DESCRIPTION
Closes #144.

The old flag `--capsule-user-group` will be still available to preserve backward compatibility, will be removed in the next minor release.

Args passed by `--capsule-user-group` CLI flag will have precedence over `--capsule-configuration-name`.