### PR TITLE
Releasing capsule-proxy v0.2.0

### DIFF
--- a/charts/capsule-proxy/Chart.yaml
+++ b/charts/capsule-proxy/Chart.yaml
@@ -1,6 +1,6 @@
 apiVersion: v2
-appVersion: 0.1.1
+appVersion: 0.2.0
 description: Helm Chart for Capsule Proxy, addon for Capsule, the multi-tenant Operator
 name: capsule-proxy
 type: application
-version: 0.1.7
+version: 0.1.8


### PR DESCRIPTION
Tagging on GitHub after merging this PR that will fail.