### PR TITLE
fix: ingress service reference in networking.k8s.io/v1

### DIFF
--- a/charts/capsule-proxy/Chart.yaml
+++ b/charts/capsule-proxy/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: 0.2.0
 description: Helm Chart for Capsule Proxy, addon for Capsule, the multi-tenant Operator
 name: capsule-proxy
 type: application
-version: 0.1.8
+version: 0.1.9

--- a/charts/capsule-proxy/templates/ingress.yaml
+++ b/charts/capsule-proxy/templates/ingress.yaml
@@ -1,6 +1,6 @@
 {{- if .Values.ingress.enabled -}}
 {{- $fullName := include "capsule-proxy.fullname" . -}}
-{{- if semverCompare ">=1.12-0" .Capabilities.KubeVersion.GitVersion -}}
+{{- if .Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" -}}
 apiVersion: networking.k8s.io/v1
 {{- else -}}
 apiVersion: networking.k8s.io/v1beta1
@@ -31,10 +31,20 @@ spec:
     http:
       paths:
       {{- range .paths }}
+      {{- if $.Capabilities.APIVersions.Has "networking.k8s.io/v1/Ingress" }}
+      - path: {{ . }}
+        pathType: ImplementationSpecific
+        backend:
+          service:
+            name: {{ $fullName }}
+            port:
+              number: {{ $.Values.service.port }}
+      {{- else }}
       - path: {{ . }}
         backend:
           serviceName: {{ $fullName }}
           servicePort: {{ $.Values.service.port }}
+      {{- end }}
       {{- end }}
   {{- end }}
   {{- end }}


### PR DESCRIPTION
Failed to deploy on k8s v1.22 before this change.
As per https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.22/#httpingresspath-v1-networking-k8s-io

Capsule is great, thank you! :)