### PR TITLE
bug: cve exploiting malicious connection header

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ ARG TARGETARCH
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GO111MODULE=on go build -gcflags "${GCFLAGS}" -a -o capsule-proxy main.go
 
 FROM golang:1.16-alpine as dlv
-RUN go install github.com/go-delve/delve/cmd/dlv@latest
+RUN CGO_ENABLED=0 go install github.com/go-delve/delve/cmd/dlv@latest
 WORKDIR /
 COPY --from=builder /workspace/capsule-proxy .
 ENTRYPOINT ["dlv", "--listen=:2345", "--headless=true", "--api-version=2", "--accept-multiclient", "exec", "--", "/capsule-proxy"]

--- a/Makefile
+++ b/Makefile
@@ -54,7 +54,8 @@ ifeq ($(CAPSULE_PROXY_MODE),http)
 		--set "service.type=NodePort" \
 		--set "service.nodePort=" \
 		--set "kind=DaemonSet" \
-		--set "daemonset.hostNetwork=true"
+		--set "daemonset.hostNetwork=true" \
+		--set "serviceMonitor.enabled=false"
 else
 	@echo "Running in HTTPS mode"
 	@echo "capsule proxy certificates..."
@@ -85,7 +86,8 @@ else
 		--set "service.type=NodePort" \
 		--set "service.nodePort=" \
 		--set "kind=DaemonSet" \
-		--set "daemonset.hostNetwork=true"
+		--set "daemonset.hostNetwork=true" \
+		--set "serviceMonitor.enabled=false"
 endif
 
 rbac-fix:

--- a/go.mod
+++ b/go.mod
@@ -11,6 +11,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/spf13/pflag v1.0.5
 	go.uber.org/zap v1.18.1
+	golang.org/x/net v0.0.0-20210520170846-37e1c6afe023
 	k8s.io/api v0.22.0
 	k8s.io/apimachinery v0.22.1
 	k8s.io/apiserver v0.22.0


### PR DESCRIPTION
Closes #188.

We strongly suggest upgrading ASAP `capsule-proxy` to mitigate this CVE that doesn't have direct mitigation.