### PR TITLE
Fix webtoken auth

### DIFF
--- a/internal/webserver/middleware/authorization.go
+++ b/internal/webserver/middleware/authorization.go
@@ -26,7 +26,7 @@ func CheckAuthorization(client client.Client, log logr.Logger, tls bool) mux.Mid
 
 			isCertificates := request.TLS != nil && len(request.TLS.PeerCertificates) > 0
 
-			isBearerToken, errBT := checkBearerToken(request.Header.Get("Authorization"))
+			isBearerToken, errBT := CheckBearerToken(request.Header.Get("Authorization"))
 
 			unauthorized := errBT != nil || (tls && (!isCertificates && !isBearerToken)) || (!tls && !isBearerToken)
 
@@ -39,7 +39,7 @@ func CheckAuthorization(client client.Client, log logr.Logger, tls bool) mux.Mid
 	}
 }
 
-func checkBearerToken(authorizationHeader string) (bool, error) {
+func CheckBearerToken(authorizationHeader string) (bool, error) {
 	if authorizationHeader == "" {
 		return false, nil
 	}

--- a/internal/webserver/middleware/authorization.go
+++ b/internal/webserver/middleware/authorization.go
@@ -16,7 +16,7 @@ import (
 )
 
 const (
-	regexPatternForAuthHeader = "^(Bearer ([\\w-]*\\.[\\w-]*\\.[\\w-]*))$"
+	regexPatternForAuthHeader = "^(Bearer ([\\w-]*\\.[\\w-]*\\.[\\w-]*|[\\w-]*))$"
 )
 
 func CheckAuthorization(client client.Client, log logr.Logger, tls bool) mux.MiddlewareFunc {

--- a/internal/webserver/middleware/authorization_test.go
+++ b/internal/webserver/middleware/authorization_test.go
@@ -1,14 +1,18 @@
 // Copyright 2020-2021 Clastix Labs
 // SPDX-License-Identifier: Apache-2.0
 
-package middleware
+package middleware_test
 
 import (
 	"testing"
+
+	"github.com/clastix/capsule-proxy/internal/webserver/middleware"
 )
 
 func TestCheckBearerToken(t *testing.T) {
-	var tests = []struct {
+	t.Parallel()
+
+	tests := []struct {
 		name  string
 		token string
 		want  bool
@@ -20,13 +24,15 @@ func TestCheckBearerToken(t *testing.T) {
 		{"fail space in token", "Bearer alksjdas239ld asdasd123lksadsj", false, false},
 	}
 
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			got, err := checkBearerToken(tt.token)
-			if got != tt.want {
-				t.Errorf("got %v, want %v", got, tt.want)
+	for _, eachTest := range tests {
+		eachTest := eachTest
+		t.Run(eachTest.name, func(t *testing.T) {
+			t.Parallel()
+			got, err := middleware.CheckBearerToken(eachTest.token)
+			if got != eachTest.want {
+				t.Errorf("got %v, want %v", got, eachTest.want)
 			}
-			if err != nil && !tt.err {
+			if err != nil && !eachTest.err {
 				t.Errorf("got error: %v", err)
 			}
 		})

--- a/internal/webserver/middleware/authorization_test.go
+++ b/internal/webserver/middleware/authorization_test.go
@@ -1,0 +1,34 @@
+// Copyright 2020-2021 Clastix Labs
+// SPDX-License-Identifier: Apache-2.0
+
+package middleware
+
+import (
+	"testing"
+)
+
+func TestCheckBearerToken(t *testing.T) {
+	var tests = []struct {
+		name  string
+		token string
+		want  bool
+		err   bool
+	}{
+		{"fail no bearer", "alksjdas239ldasdasd123ljksadsj", false, false},
+		{"pass jwt", "Bearer eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c", true, false},
+		{"pass webtoken", "Bearer alksjdas2_9ldas-dasd123ljksadsj", true, false},
+		{"fail space in token", "Bearer alksjdas239ld asdasd123lksadsj", false, false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := checkBearerToken(tt.token)
+			if got != tt.want {
+				t.Errorf("got %v, want %v", got, tt.want)
+			}
+			if err != nil && !tt.err {
+				t.Errorf("got error: %v", err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Issue: the regex pattern for the checkBearerToken function currently does not support webtokens.

Solution: This PR added makes it so that both webtokens and jwts pass the regex

Reference https://github.com/clastix/capsule-proxy/issues/194