### PR TITLE
deploy(charts): move certgen job to chart resources

### DIFF
--- a/charts/capsule-proxy/Chart.yaml
+++ b/charts/capsule-proxy/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.2.1
 description: Helm Chart for Capsule Proxy, addon for Capsule, the multi-tenant Operator
 name: capsule-proxy
 type: application
-version: 0.2.3
+version: 0.2.4
 home: https://github.com/clastix/capsule-proxy
 icon: https://github.com/clastix/capsule/raw/master/assets/logo/capsule_small.png
 keywords:

--- a/charts/capsule-proxy/README.md
+++ b/charts/capsule-proxy/README.md
@@ -67,9 +67,9 @@ If you only need to make minor customizations, you can specify them on the comma
 | image.repository | string | `"quay.io/clastix/capsule-proxy"` | Set the image repository of the capsule-proxy. |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | Configuration for `imagePullSecrets` so that you can use a private images registry. |
-| jobs.certs.pullPolicy | string | `"IfNotPresent"` | Set the image pull policy of the post install certgen job |
-| jobs.certs.repository | string | `"docker.io/jettech/kube-webhook-certgen"` | Set the image repository of the post install certgen job |
-| jobs.certs.tag | string | `"v1.3.0"` | Set the image tag of the post install certgen job |
+| jobs.certs.pullPolicy | string | `"IfNotPresent"` | Set the image pull policy of the certgen job |
+| jobs.certs.repository | string | `"docker.io/jettech/kube-webhook-certgen"` | Set the image repository of the certgen job |
+| jobs.certs.tag | string | `"v1.3.0"` | Set the image tag of the certgen job |
 | kind | string | `"Deployment"` | Set the deployment mode of the capsule-proxy as `Deployment` or `DaemonSet`.  |
 | nodeSelector | object | `{}` | Set the node selector for the capsule-proxy pod. |
 | podAnnotations | object | `{}` | Annotations to add to the capsule-proxy pod. |
@@ -185,4 +185,4 @@ metadata:
   namespace: capsule-system
 type: Opaque
 ```
-Otherwise, you can set `options.generateCertificates` to `true` and self-signed certificates will be generated during deployment process by a post-install job.
+Otherwise, you can set `options.generateCertificates` to `true` and self-signed certificates will be generated during deployment process by a job.

--- a/charts/capsule-proxy/templates/certgen-job.yaml
+++ b/charts/capsule-proxy/templates/certgen-job.yaml
@@ -8,12 +8,6 @@ metadata:
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
     app.kubernetes.io/version: {{ .Chart.AppVersion }}
     helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
-  annotations:
-    # This is what defines this resource as a hook. Without this line, the
-    # job is considered part of the release.
-    "helm.sh/hook": "post-install"
-    "helm.sh/hook-weight": "-5"
-    "helm.sh/hook-delete-policy": hook-succeeded
 spec:
   template:
     metadata:


### PR DESCRIPTION
This PR fixes #211 by including the certificate generation Job to the Helm chart resources, from [post-install hooks](https://helm.sh/docs/topics/charts_hooks/#hooks-and-the-release-lifecycle).

Signed-off-by: Massimiliano Giovagnoli <me@maxgio.it>