### PR TITLE
Handle GetUserAndGroups() failure for missing privileges

### DIFF
--- a/internal/request/error.go
+++ b/internal/request/error.go
@@ -1,0 +1,14 @@
+package request
+
+type ErrUnauthorized struct {
+	message string
+}
+
+func NewErrUnauthorized(message string) *ErrUnauthorized {
+	return &ErrUnauthorized{
+		message: message,
+	}
+}
+func (e *ErrUnauthorized) Error() string {
+	return e.message
+}

--- a/internal/request/http.go
+++ b/internal/request/http.go
@@ -80,7 +80,7 @@ func (h http) GetUserAndGroups() (username string, groups []string, err error) {
 		}
 
 		if !ac.Status.Allowed {
-			return "", nil, fmt.Errorf("the current user %s cannot impersonate the user %s", username, impersonateUser)
+			return "", nil, NewErrUnauthorized(fmt.Sprintf("the current user %s cannot impersonate the user %s", username, impersonateUser))
 		}
 		// The current user is allowed to perform authentication, allowing the override
 		username = impersonateUser

--- a/internal/webserver/webserver.go
+++ b/internal/webserver/webserver.go
@@ -178,7 +178,12 @@ func (n kubeFilter) impersonateHandler(writer http.ResponseWriter, request *http
 	var err error
 
 	if username, groups, err = hr.GetUserAndGroups(); err != nil {
-		serverr.HandleError(writer, err, "cannot retrieve user and group")
+		switch err.(type) {
+		default:
+			serverr.HandleError(writer, err, "cannot retrieve user and group")
+		case *req.ErrUnauthorized:
+			serverr.HandleUnauthorized(writer, err, "cannot retrieve user and group")
+		}
 	}
 
 	n.log.V(4).Info("impersonating for the current request", "username", username, "groups", groups)

--- a/internal/webserver/webserver.go
+++ b/internal/webserver/webserver.go
@@ -178,11 +178,13 @@ func (n kubeFilter) impersonateHandler(writer http.ResponseWriter, request *http
 	var err error
 
 	if username, groups, err = hr.GetUserAndGroups(); err != nil {
+		msg := "cannot retrieve user and group"
+
 		switch err.(type) {
 		default:
-			server.HandleError(writer, err, "cannot retrieve user and group")
+			server.HandleError(writer, err, msg)
 		case *req.ErrUnauthorized:
-			server.HandleUnauthorized(writer, err, "cannot retrieve user and group")
+			server.HandleUnauthorized(writer, err, msg)
 		}
 	}
 

--- a/internal/webserver/webserver.go
+++ b/internal/webserver/webserver.go
@@ -42,7 +42,7 @@ import (
 	"github.com/clastix/capsule-proxy/internal/options"
 	req "github.com/clastix/capsule-proxy/internal/request"
 	"github.com/clastix/capsule-proxy/internal/tenant"
-	serverr "github.com/clastix/capsule-proxy/internal/webserver/errors"
+	server "github.com/clastix/capsule-proxy/internal/webserver/errors"
 	"github.com/clastix/capsule-proxy/internal/webserver/middleware"
 )
 
@@ -180,9 +180,9 @@ func (n kubeFilter) impersonateHandler(writer http.ResponseWriter, request *http
 	if username, groups, err = hr.GetUserAndGroups(); err != nil {
 		switch err.(type) {
 		default:
-			serverr.HandleError(writer, err, "cannot retrieve user and group")
+			server.HandleError(writer, err, "cannot retrieve user and group")
 		case *req.ErrUnauthorized:
-			serverr.HandleUnauthorized(writer, err, "cannot retrieve user and group")
+			server.HandleUnauthorized(writer, err, "cannot retrieve user and group")
 		}
 	}
 
@@ -240,7 +240,7 @@ func (n kubeFilter) registerModules(ctx context.Context, root *mux.Router) {
 			username, groups, _ := proxyRequest.GetUserAndGroups()
 			proxyTenants, err := n.getTenantsForOwner(ctx, username, groups)
 			if err != nil {
-				serverr.HandleError(writer, err, "cannot list Tenant resources")
+				server.HandleError(writer, err, "cannot list Tenant resources")
 			}
 
 			var selector labels.Selector
@@ -254,7 +254,7 @@ func (n kubeFilter) registerModules(ctx context.Context, root *mux.Router) {
 					_, _ = writer.Write(b)
 					panic(err.Error())
 				}
-				serverr.HandleError(writer, err, err.Error())
+				server.HandleError(writer, err, err.Error())
 			case selector == nil:
 				// if there's no selector, let it pass to the
 				n.impersonateHandler(writer, request)


### PR DESCRIPTION
This PR adds a specific error type return and management when the user and groups that are wanted to be impersonated can't be due to missing privileges.