### PR TITLE
fix: implementing hijack interface for metrics middleware

### DIFF
--- a/internal/webserver/middleware/metrics.go
+++ b/internal/webserver/middleware/metrics.go
@@ -4,6 +4,9 @@
 package middleware
 
 import (
+	"bufio"
+	"fmt"
+	"net"
 	"net/http"
 	"strconv"
 
@@ -21,6 +24,15 @@ func init() {
 type httpResponseWriter struct {
 	http.ResponseWriter
 	statusCode int
+}
+
+func (h *httpResponseWriter) Hijack() (net.Conn, *bufio.ReadWriter, error) {
+	hijacker, ok := h.ResponseWriter.(http.Hijacker)
+	if !ok {
+		return nil, nil, fmt.Errorf("writer is not http.Hijacker")
+	}
+
+	return hijacker.Hijack()
 }
 
 func newHTTPResponseWriter(w http.ResponseWriter) *httpResponseWriter {


### PR DESCRIPTION
Fixes #224.

@viveksyngh please, take a look: I was able to exec in a Pod and getting metrics populated properly.

```
KUBECONFIG=alice-solar.capsule kubectl -n solar-development exec -it nginx-798bbb699b-rxfrk bash
kubectl exec [POD] [COMMAND] is DEPRECATED and will be removed in a future version. Use kubectl exec [POD] -- [COMMAND] instead.
nginx@nginx-798bbb699b-rxfrk:/$ echo 1
1
nginx@nginx-798bbb699b-rxfrk:/$ 
exit
```

```
curl -s localhost:8080/metrics | grep -i capsule_proxy
# HELP capsule_proxy_requests_total Number of requests
# TYPE capsule_proxy_requests_total counter
capsule_proxy_requests_total{path="/",status="200"} 36
# HELP capsule_proxy_response_time_seconds Duration of capsule proxy requests.
# TYPE capsule_proxy_response_time_seconds histogram
capsule_proxy_response_time_seconds_bucket{path="/",le="0.005"} 1
capsule_proxy_response_time_seconds_bucket{path="/",le="0.01"} 1
capsule_proxy_response_time_seconds_bucket{path="/",le="0.025"} 1
capsule_proxy_response_time_seconds_bucket{path="/",le="0.05"} 1
capsule_proxy_response_time_seconds_bucket{path="/",le="0.1"} 1
capsule_proxy_response_time_seconds_bucket{path="/",le="0.25"} 1
capsule_proxy_response_time_seconds_bucket{path="/",le="0.5"} 3
capsule_proxy_response_time_seconds_bucket{path="/",le="1"} 19
capsule_proxy_response_time_seconds_bucket{path="/",le="2.5"} 36
capsule_proxy_response_time_seconds_bucket{path="/",le="5"} 36
capsule_proxy_response_time_seconds_bucket{path="/",le="10"} 36
capsule_proxy_response_time_seconds_bucket{path="/",le="+Inf"} 36
capsule_proxy_response_time_seconds_sum{path="/"} 37.59395716100001
capsule_proxy_response_time_seconds_count{path="/"} 36
```