### PR TITLE
feat: support ingressclassname in chart

### DIFF
--- a/charts/capsule-proxy/README.md
+++ b/charts/capsule-proxy/README.md
@@ -125,6 +125,7 @@ If you only need to make minor customizations, you can specify them on the comma
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | ingress.annotations | object | `{}` | Annotations to add to the capsule-proxy ingress. |
+| ingress.className | string | `""` | Set the IngressClass to use for the capsule-proxy ingress (do not set via annotations if setting here). |
 | ingress.enabled | bool | `false` | Specifies whether an ingress should be created. |
 | ingress.hosts[0] | object | `{"host":"kube.clastix.io","paths":["/"]}` | Set the host configuration for the capsule-proxy ingress. |
 | ingress.hosts[0].paths | list | `["/"]` | Set the path configuration for the capsule-proxy ingress. |

--- a/charts/capsule-proxy/templates/ingress.yaml
+++ b/charts/capsule-proxy/templates/ingress.yaml
@@ -15,6 +15,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
   {{- if .Values.ingress.tls }}
   tls:
     {{- range .Values.ingress.tls }}

--- a/charts/capsule-proxy/values.yaml
+++ b/charts/capsule-proxy/values.yaml
@@ -172,6 +172,8 @@ service:
 ingress:
   # -- Specifies whether an ingress should be created.
   enabled: false
+  # -- Set the IngressClass to use for the capsule-proxy ingress (do not set via annotations if setting here).
+  className: ""
   # -- Annotations to add to the capsule-proxy ingress.
   annotations: {}
   hosts:


### PR DESCRIPTION
The ingress class annotation (e.g. `kubernetes.io/ingress.class: nginx`) has been deprecated since Kubernetes 1.18. This change adds support for setting `ingress.className` in the chart values which in turn sets the `spec.ingressClassName` field on the Ingress object for Capsule Proxy. `ingress.className` should refer to an existing `IngressClass` object. Note, the annotation and `ingressClassName` field cannot be used together or you'll get an error from the Kubernetes API.