### PR TITLE
feat: support for clusterissuer in chart

### DIFF
--- a/charts/capsule-proxy/Chart.yaml
+++ b/charts/capsule-proxy/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.3.2
 description: Helm Chart for Capsule Proxy, addon for Capsule, the multi-tenant Operator
 name: capsule-proxy
 type: application
-version: 0.3.3
+version: 0.3.4
 home: https://github.com/clastix/capsule-proxy
 icon: https://github.com/clastix/capsule/raw/master/assets/logo/capsule_small.png
 keywords:

--- a/charts/capsule-proxy/README.md
+++ b/charts/capsule-proxy/README.md
@@ -64,6 +64,8 @@ If you only need to make minor customizations, you can specify them on the comma
 | certManager.externalCA.enabled | bool | `false` |  |
 | certManager.externalCA.secretName | string | `""` |  |
 | certManager.generateCertificates | bool | `false` | Set if the cert manager will generate self-signed SSL certificates |
+| certManager.issuer.kind | string | `"Issuer"` | Set if the cert manager will generate either self-signed or CA signed SSL certificates. Its value will be either Issuer or ClusterIssuer |
+| certManager.issuer.name | string | `""` | Set the name of the ClusterIssuer if issuer kind is ClusterIssuer and if cert manager will generate CA signed SSL certificates |
 | daemonset.hostNetwork | bool | `false` | Use the host network namespace for capsule-proxy pod. |
 | daemonset.hostPort | bool | `false` | Binding the capsule-proxy listening port to the host port. |
 | image.pullPolicy | string | `"IfNotPresent"` | Set the image pull policy. |

--- a/charts/capsule-proxy/ci/deploy-values.yaml
+++ b/charts/capsule-proxy/ci/deploy-values.yaml
@@ -6,6 +6,9 @@ certManager:
     enabled: false
     # secret containing the CA cert and private key of the external CA in the correct cert-manager format as per https://cert-manager.io/docs/configuration/ca/#deployment
     secretName: ""
+  issuer:
+    kind: Issuer # Issuer or ClusterIssuer
+    name: "" #  Name of the ClusterIssuer
 replicaCount: 1
 podAnnotations:
   scheduler.alpha.kubernetes.io/critical-pod: ''

--- a/charts/capsule-proxy/ci/ds-values.yaml
+++ b/charts/capsule-proxy/ci/ds-values.yaml
@@ -9,6 +9,9 @@ certManager:
     enabled: false
     # secret containing the CA cert and private key of the external CA in the correct cert-manager format as per https://cert-manager.io/docs/configuration/ca/#deployment
     secretName: ""
+  issuer:
+    kind: Issuer # Issuer or ClusterIssuer
+    name: "" #  Name of the ClusterIssuer
 replicaCount: 1
 podAnnotations:
   scheduler.alpha.kubernetes.io/critical-pod: ''

--- a/charts/capsule-proxy/templates/_helpers.tpl
+++ b/charts/capsule-proxy/templates/_helpers.tpl
@@ -85,3 +85,14 @@ Create CA secret name for the capsule proxy
 {{- printf "%s-root-secret" (include "capsule-proxy.fullname" .) -}}
 {{- end -}}
 {{- end -}}
+
+{{/*
+Create Cert Manager issuer name for the capsule proxy
+*/}}
+{{- define "capsule-proxy.certManager.issuerName" -}}
+{{- if eq .Values.certManager.issuer.kind "ClusterIssuer" -}}
+{{- printf "%s" .Values.certManager.issuer.name -}}
+{{- else -}}
+{{- printf "%s-ca-issuer" (include "capsule-proxy.fullname" .) -}}
+{{- end -}}
+{{- end -}}

--- a/charts/capsule-proxy/templates/certmanager.yaml
+++ b/charts/capsule-proxy/templates/certmanager.yaml
@@ -1,5 +1,5 @@
 {{- if and .Values.certManager.generateCertificates .Values.options.enableSSL -}}
-  {{- if not .Values.certManager.externalCA.enabled  -}}
+  {{- if and (not .Values.certManager.externalCA.enabled) (eq .Values.certManager.issuer.kind "Issuer")  -}}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -24,6 +24,7 @@ spec:
     group: cert-manager.io
   {{- end }}
 ---
+  {{- if eq .Values.certManager.issuer.kind "Issuer" }}
 apiVersion: cert-manager.io/v1
 kind: Issuer
 metadata:
@@ -31,6 +32,7 @@ metadata:
 spec:
   ca:
     secretName: {{ include "capsule-proxy.caSecretName" . }}
+  {{- end }}    
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -42,8 +44,8 @@ spec:
   - {{ $hosts.host }}
   {{- end }}
   issuerRef:
-    kind: Issuer
-    name: {{ include "capsule-proxy.fullname" . }}-ca-issuer
+    kind: {{ .Values.certManager.issuer.kind }}
+    name: {{ include "capsule-proxy.certManager.issuerName" . }}
   secretName: {{ include "capsule-proxy.fullname" . }}
   subject:
     organizations:

--- a/charts/capsule-proxy/values.yaml
+++ b/charts/capsule-proxy/values.yaml
@@ -57,6 +57,11 @@ certManager:
     enabled: false
     # secret containing the CA cert and private key of the external CA in the correct cert-manager format as per https://cert-manager.io/docs/configuration/ca/#deployment
     secretName: ""
+  issuer:
+    # -- Set if the cert manager will generate either self-signed or CA signed SSL certificates. Its value will be either Issuer or ClusterIssuer
+    kind: Issuer # Issuer or ClusterIssuer
+    # -- Set the name of the ClusterIssuer if issuer kind is ClusterIssuer and if cert manager will generate CA signed SSL certificates
+    name: "" #  Name of the ClusterIssuer
 
 
 # ServiceAccount


### PR DESCRIPTION
Currently in [certmanager.yaml](https://github.com/clastix/capsule-proxy/blob/master/charts/capsule-proxy/templates/certmanager.yaml) following use cases are supported:

- Generate self-signed certificates for capsule-proxy using the self-signed issuer
- Generate the ca signed certificates for capsule-proxy using the ca-issuer

With this pull request I am adding support for one more use case details of which are as follows:

- I have a ClusterIssuer in the K8s cluster which is used by all the apps in the cluster for Certificate generation
- For capsule-proxy instead of using self signed issuer or ca issuer I want to use ClusterIssuer to generate capsule-proxy-serving-cert.

I refactored  [certmanager.yaml](https://github.com/clastix/capsule-proxy/blob/master/charts/capsule-proxy/templates/certmanager.yaml) to add support for this use case.