### PR TITLE
Set correct SANs when using cert-manager

### DIFF
--- a/charts/capsule-proxy/Chart.yaml
+++ b/charts/capsule-proxy/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.3.3
 description: Helm Chart for Capsule Proxy, addon for Capsule, the multi-tenant Operator
 name: capsule-proxy
 type: application
-version: 0.3.6
+version: 0.3.7
 home: https://github.com/clastix/capsule-proxy
 icon: https://github.com/clastix/capsule/raw/master/assets/logo/capsule_small.png
 keywords:

--- a/charts/capsule-proxy/README.md
+++ b/charts/capsule-proxy/README.md
@@ -61,9 +61,9 @@ If you only need to make minor customizations, you can specify them on the comma
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | Set affinity rules for the capsule-proxy pod. |
-| certManager.externalCA.enabled | bool | `false` |  |
+| certManager.externalCA.enabled | bool | `false` | Set if want cert manager to sign certificates with an external CA |
 | certManager.externalCA.secretName | string | `""` |  |
-| certManager.generateCertificates | bool | `false` | Set if the cert manager will generate self-signed SSL certificates |
+| certManager.generateCertificates | bool | `false` | Set if the cert manager will generate SSL certificates (self-signed or CA-signed) |
 | certManager.issuer.kind | string | `"Issuer"` | Set if the cert manager will generate either self-signed or CA signed SSL certificates. Its value will be either Issuer or ClusterIssuer |
 | certManager.issuer.name | string | `""` | Set the name of the ClusterIssuer if issuer kind is ClusterIssuer and if cert manager will generate CA signed SSL certificates |
 | daemonset.hostNetwork | bool | `false` | Use the host network namespace for capsule-proxy pod. |

--- a/charts/capsule-proxy/templates/_helpers.tpl
+++ b/charts/capsule-proxy/templates/_helpers.tpl
@@ -91,7 +91,7 @@ Create Cert Manager issuer name for the capsule proxy
 */}}
 {{- define "capsule-proxy.certManager.issuerName" -}}
 {{- if eq .Values.certManager.issuer.kind "ClusterIssuer" -}}
-{{- printf "%s" .Values.certManager.issuer.clusterIssuerName -}}
+{{- printf "%s" .Values.certManager.issuer.name -}}
 {{- else -}}
 {{- printf "%s-ca-issuer" (include "capsule-proxy.fullname" .) -}}
 {{- end -}}

--- a/charts/capsule-proxy/templates/_helpers.tpl
+++ b/charts/capsule-proxy/templates/_helpers.tpl
@@ -91,7 +91,7 @@ Create Cert Manager issuer name for the capsule proxy
 */}}
 {{- define "capsule-proxy.certManager.issuerName" -}}
 {{- if eq .Values.certManager.issuer.kind "ClusterIssuer" -}}
-{{- printf "%s" .Values.certManager.issuer.name -}}
+{{- printf "%s" .Values.certManager.issuer.clusterIssuerName -}}
 {{- else -}}
 {{- printf "%s-ca-issuer" (include "capsule-proxy.fullname" .) -}}
 {{- end -}}

--- a/charts/capsule-proxy/templates/certmanager.yaml
+++ b/charts/capsule-proxy/templates/certmanager.yaml
@@ -40,9 +40,13 @@ metadata:
   name: {{ include "capsule-proxy.fullname" . }}-serving-cert
 spec:
   dnsNames:
-  {{- range $hosts := .Values.ingress.hosts }}
+  {{- if .Values.ingress.enabled -}}
+    {{- range $hosts := .Values.ingress.hosts }}
   - {{ $hosts.host }}
+    {{- end }}
   {{- end }}
+  - {{ include "capsule-proxy.fullname" . }}
+  - {{ include "capsule-proxy.fullname" . }}.{{ .Release.Namespace }}.svc
   issuerRef:
     kind: {{ .Values.certManager.issuer.kind }}
     name: {{ include "capsule-proxy.certManager.issuerName" . }}

--- a/charts/capsule-proxy/values.yaml
+++ b/charts/capsule-proxy/values.yaml
@@ -79,7 +79,7 @@ certManager:
     # -- Its value will be either Issuer or ClusterIssuer
     kind: Issuer # Issuer or ClusterIssuer
     # -- Set the name of the ClusterIssuer if issuer kind is ClusterIssuer and if cert manager will generate CA signed SSL certificates
-    clusterIssuerName: "" #  Name of the ClusterIssuer
+    name: "" #  Name of the ClusterIssuer
 
 
 # ServiceAccount

--- a/charts/capsule-proxy/values.yaml
+++ b/charts/capsule-proxy/values.yaml
@@ -75,8 +75,7 @@ certManager:
     # secret containing the CA cert and private key of the external CA in the correct cert-manager format as per https://cert-manager.io/docs/configuration/ca/#deployment
     secretName: ""
   issuer:
-    # -- Set if the cert manager will generate either self-signed or CA signed SSL certificates.
-    # -- Its value will be either Issuer or ClusterIssuer
+    # -- Set if the cert manager will generate either self-signed or CA signed SSL certificates. Its value will be either Issuer or ClusterIssuer
     kind: Issuer # Issuer or ClusterIssuer
     # -- Set the name of the ClusterIssuer if issuer kind is ClusterIssuer and if cert manager will generate CA signed SSL certificates
     name: "" #  Name of the ClusterIssuer

--- a/charts/capsule-proxy/values.yaml
+++ b/charts/capsule-proxy/values.yaml
@@ -67,17 +67,19 @@ options:
   rolebindingsResyncPeriod: 10h
 
 certManager:
-  # -- Set if the cert manager will generate self-signed SSL certificates
+  # -- Set if the cert manager will generate SSL certificates (self-signed or CA-signed)
   generateCertificates: false
   externalCA:
+    # -- Set if want cert manager to sign certificates with an external CA
     enabled: false
     # secret containing the CA cert and private key of the external CA in the correct cert-manager format as per https://cert-manager.io/docs/configuration/ca/#deployment
     secretName: ""
   issuer:
-    # -- Set if the cert manager will generate either self-signed or CA signed SSL certificates. Its value will be either Issuer or ClusterIssuer
+    # -- Set if the cert manager will generate either self-signed or CA signed SSL certificates.
+    # -- Its value will be either Issuer or ClusterIssuer
     kind: Issuer # Issuer or ClusterIssuer
     # -- Set the name of the ClusterIssuer if issuer kind is ClusterIssuer and if cert manager will generate CA signed SSL certificates
-    name: "" #  Name of the ClusterIssuer
+    clusterIssuerName: "" #  Name of the ClusterIssuer
 
 
 # ServiceAccount


### PR DESCRIPTION
This PR adds the Kubernetes `Service` DNS names to the DNS SANs of the Cert Manager generated `Certificate`.
Moreover, it removes the host name of the main `Ingress` rule when the ingress is disabled.

Finally, removes ambiguity in the variable names and adds documenting comments.

Fixes #262