### PR TITLE
fix: do not expose service name to anonymous requests

### DIFF
--- a/internal/request/http.go
+++ b/internal/request/http.go
@@ -41,7 +41,7 @@ func (h http) GetUserAndGroups() (username string, groups []string, err error) {
 	case BearerToken:
 		username, groups, err = h.processBearerToken()
 	case Anonymous:
-		return "", nil, fmt.Errorf("capsule does not support unauthenticated users")
+		return "", nil, fmt.Errorf("unauthenticated users not supported")
 	}
 	// In case of error, we're blocking the request flow here
 	if err != nil {


### PR DESCRIPTION
If you are not authenticated, don't return the `capsule` name in the error message. This helps reduce information leaking to anonymous requests. 