### PR TITLE
only verify client cert if TLSCertAuth is active

### DIFF
--- a/internal/webserver/webserver.go
+++ b/internal/webserver/webserver.go
@@ -275,6 +275,7 @@ func (n *kubeFilter) registerModules(ctx context.Context, root *mux.Router) {
 	}
 }
 
+//nolint:funlen
 func (n *kubeFilter) Start(ctx context.Context) error {
 	r := mux.NewRouter()
 	r.Use(handlers.RecoveryHandler())
@@ -306,8 +307,16 @@ func (n *kubeFilter) Start(ctx context.Context) error {
 			tlsConfig := &tls.Config{
 				MinVersion: tls.VersionTLS12,
 				ClientCAs:  n.serverOptions.GetCertificateAuthorityPool(),
-				ClientAuth: tls.VerifyClientCertIfGiven,
 			}
+
+			for _, authType := range n.authTypes {
+				if authType == req.TLSCertificate {
+					tlsConfig.ClientAuth = tls.VerifyClientCertIfGiven
+
+					break
+				}
+			}
+
 			srv = &http.Server{
 				Handler:   r,
 				Addr:      addr,


### PR DESCRIPTION
* If `TLSCertAuth` is not provided as one of the preferred auth types then skip verification

closes #271