### PR TITLE
chore(helm): Allow to specify authPreferredTypes

### DIFF
--- a/charts/capsule-proxy/Chart.yaml
+++ b/charts/capsule-proxy/Chart.yaml
@@ -1,9 +1,9 @@
 apiVersion: v2
-appVersion: 0.4.1
+appVersion: 0.4.2
 description: Helm Chart for Capsule Proxy, addon for Capsule, the multi-tenant Operator
 name: capsule-proxy
 type: application
-version: 0.4.2
+version: 0.4.3
 home: https://github.com/clastix/capsule-proxy
 icon: https://github.com/clastix/capsule/raw/master/assets/logo/capsule_small.png
 keywords:

--- a/charts/capsule-proxy/README.md
+++ b/charts/capsule-proxy/README.md
@@ -104,10 +104,10 @@ If you only need to make minor customizations, you can specify them on the comma
 | options.SSLDirectory | string | `"/opt/capsule-proxy"` | Set the directory, where SSL certificate and keyfile will be located |
 | options.SSLKeyFileName | string | `"tls.key"` | Set the name of SSL key file |
 | options.additionalSANs | list | `[]` | Specify additional subject alternative names for the self-signed SSL |
+| options.authPreferredTypes | string | `"BearerToken,TLSCertificate"` | Authentication types to be used for requests. Possible Auth Types: [BearerToken, TLSCertificate] |
 | options.capsuleConfigurationName | string | `"default"` | Name of the CapsuleConfiguration custom resource used by Capsule, required to identify the user groups |
 | options.certificateVolumeName | string | `""` | Specify an override for the Secret containing the certificate for SSL. Default value is empty and referring to the generated certificate. |
 | options.disableCaching | bool | `false` | Disable the go-client caching to hit directly the Kubernetes API Server, it disables any local caching as the rolebinding reflector |
-| options.authPreferredTypes | string | `BearerToken,TLSCertificate` | Authentication types to be used for requests. Possible Auth Types: [BearerToken, TLSCertificate] |
 | options.enableSSL | bool | `true` | Specify if capsule-proxy will use SSL |
 | options.generateCertificates | bool | `true` | Specify if capsule-proxy will generate self-signed SSL certificates |
 | options.ignoredUserGroups | list | `[]` | Define which groups must be ignored while proxying requests |

--- a/charts/capsule-proxy/README.md
+++ b/charts/capsule-proxy/README.md
@@ -107,6 +107,7 @@ If you only need to make minor customizations, you can specify them on the comma
 | options.capsuleConfigurationName | string | `"default"` | Name of the CapsuleConfiguration custom resource used by Capsule, required to identify the user groups |
 | options.certificateVolumeName | string | `""` | Specify an override for the Secret containing the certificate for SSL. Default value is empty and referring to the generated certificate. |
 | options.disableCaching | bool | `false` | Disable the go-client caching to hit directly the Kubernetes API Server, it disables any local caching as the rolebinding reflector |
+| options.authPreferredTypes | string | `BearerToken,TLSCertificate` | Authentication types to be used for requests. Possible Auth Types: [BearerToken, TLSCertificate] |
 | options.enableSSL | bool | `true` | Specify if capsule-proxy will use SSL |
 | options.generateCertificates | bool | `true` | Specify if capsule-proxy will generate self-signed SSL certificates |
 | options.ignoredUserGroups | list | `[]` | Define which groups must be ignored while proxying requests |

--- a/charts/capsule-proxy/templates/_pod.tpl
+++ b/charts/capsule-proxy/templates/_pod.tpl
@@ -51,6 +51,7 @@ spec:
     - --oidc-username-claim={{ .Values.options.oidcUsernameClaim }}
     - --rolebindings-resync-period={{ .Values.options.rolebindingsResyncPeriod }}
     - --disable-caching={{ .Values.options.disableCaching }}
+    - --auth-preferred-types={{ .Values.options.authPreferredTypes }}
     {{- if .Values.options.enableSSL }}
     - --ssl-cert-path={{ .Values.options.SSLDirectory }}/{{ .Values.options.SSLCertFileName }}
     - --ssl-key-path={{ .Values.options.SSLDirectory }}/{{ .Values.options.SSLKeyFileName }}

--- a/charts/capsule-proxy/values.yaml
+++ b/charts/capsule-proxy/values.yaml
@@ -71,6 +71,8 @@ options:
   rolebindingsResyncPeriod: 10h
   # -- Disable the go-client caching to hit directly the Kubernetes API Server, it disables any local caching as the rolebinding reflector
   disableCaching: false
+  # -- Authentication types to be used for requests. Possible Auth Types: [BearerToken, TLSCertificate]
+  authPreferredTypes: "BearerToken,TLSCertificate"
 
 certManager:
   # -- Set if the cert manager will generate SSL certificates (self-signed or CA-signed)


### PR DESCRIPTION
This PR introduces `authPreferredTypes` option in helm variables, that allows to configure `--auth-preferred-types` parameter in Capsule Proxy.