### PR TITLE
fix: use uris instead of dnsNames in certificate for cluster-internal uris

### DIFF
--- a/charts/capsule-proxy/Chart.yaml
+++ b/charts/capsule-proxy/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.4.2
 description: Helm Chart for Capsule Proxy, addon for Capsule, the multi-tenant Operator
 name: capsule-proxy
 type: application
-version: 0.4.3
+version: 0.4.4
 home: https://github.com/clastix/capsule-proxy
 icon: https://github.com/clastix/capsule/raw/master/assets/logo/capsule_small.png
 keywords:

--- a/charts/capsule-proxy/templates/certmanager.yaml
+++ b/charts/capsule-proxy/templates/certmanager.yaml
@@ -32,7 +32,7 @@ metadata:
 spec:
   ca:
     secretName: {{ include "capsule-proxy.caSecretName" . }}
-  {{- end }}    
+  {{- end }}
 ---
 apiVersion: cert-manager.io/v1
 kind: Certificate
@@ -45,6 +45,7 @@ spec:
   - {{ $hosts.host }}
     {{- end }}
   {{- end }}
+  uris:
   - {{ include "capsule-proxy.fullname" . }}
   - {{ include "capsule-proxy.fullname" . }}.{{ .Release.Namespace }}.svc
   issuerRef:


### PR DESCRIPTION
This fixes the error, that a certificate could not created due to cluster-internal domains not being valid domain names.

We deployed the chart with the following values:

```yaml
    options:
      generateCertificates: false
    certManager:
      generateCertificates: true
      issuer:
        kind: ClusterIssuer
        name: letsencrypt-staging
```

but got the following errors:

```
Error creating new order :: Cannot issue for \"capsule-proxy\": Domain name needs at least one dot

and

urn:ietf:params:acme:error:rejectedIdentifier: [dns: capsule-proxy.capsule-system.svc[]
      Error creating new order :: Domain name does not end with a valid public suffix (TLD)
```

This PR fixes this by using the `uris` field instead of the `dnsNames` field for cluster-internal host names.