### PR TITLE
fix: update golang to 1.19

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -20,4 +20,4 @@ jobs:
         with:
           version: v1.51.2
           only-new-issues: false
-          args: --timeout 2m --config .golangci.yml
+          args: --timeout 5m --config .golangci.yml

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -14,7 +14,7 @@ jobs:
       - uses: actions/checkout@v2
       - uses: actions/setup-go@v2
         with:
-          go-version: '1.18'
+          go-version: '1.19'
       - name: Run golangci-lint
         uses: golangci/golangci-lint-action@v3.0.0
         with:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.18-alpine as builder
+FROM golang:1.19 as builder
 WORKDIR /workspace
 COPY go.mod go.mod
 COPY go.sum go.sum
@@ -11,7 +11,7 @@ ARG TARGETARCH
 ARG LDFLAGS=""
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=${TARGETARCH} GO111MODULE=on go build -trimpath -ldflags="${LDFLAGS}" -gcflags "${GCFLAGS}" -a -o capsule-proxy main.go
 
-FROM golang:1.18-alpine as dlv
+FROM golang:1.19 as dlv
 RUN CGO_ENABLED=0 go install github.com/go-delve/delve/cmd/dlv@latest
 WORKDIR /
 COPY --from=builder /workspace/capsule-proxy .

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/clastix/capsule-proxy
 
-go 1.18
+go 1.19
 
 require (
 	github.com/clastix/capsule v0.3.0


### PR DESCRIPTION
update golang to 1.19 to allow for easier recompile using boringcrypto added to main in 1.19. Also moved from alpine to just regular golang to standardize between capsule and capsule-proxy.