### PR TITLE
Fix fullnameoverride certgen job

### DIFF
--- a/charts/capsule-proxy/Chart.yaml
+++ b/charts/capsule-proxy/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.4.2
 description: Helm Chart for Capsule Proxy, addon for Capsule, the multi-tenant Operator
 name: capsule-proxy
 type: application
-version: 0.4.4
+version: 0.4.5
 home: https://github.com/clastix/capsule-proxy
 icon: https://github.com/clastix/capsule/raw/master/assets/logo/capsule_small.png
 keywords:

--- a/charts/capsule-proxy/templates/certgen-job.yaml
+++ b/charts/capsule-proxy/templates/certgen-job.yaml
@@ -2,23 +2,16 @@
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ .Release.Name }}-certgen"
   name: {{ include "capsule-proxy.fullname" . }}-certgen
   labels:
-    app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-    app.kubernetes.io/instance: {{ .Release.Name | quote }}
-    app.kubernetes.io/version: {{ .Chart.AppVersion }}
-    helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+    {{- include "capsule-proxy.labels" . | nindent 4 }}
 spec:
   ttlSecondsAfterFinished: 60
   template:
     metadata:
-      name: "{{ .Release.Name }}-certgen"
       name: {{ include "capsule-proxy.fullname" . }}-certgen
       labels:
-        app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
-        app.kubernetes.io/instance: {{ .Release.Name | quote }}
-        helm.sh/chart: "{{ .Chart.Name }}-{{ .Chart.Version }}"
+        {{- include "capsule-proxy.selectorLabels" . | nindent 8 }}
     spec:
       restartPolicy: Never
       {{- with $.Values.jobs.podSecurityContext }}

--- a/charts/capsule-proxy/templates/certgen-job.yaml
+++ b/charts/capsule-proxy/templates/certgen-job.yaml
@@ -3,6 +3,7 @@ apiVersion: batch/v1
 kind: Job
 metadata:
   name: "{{ .Release.Name }}-certgen"
+  name: {{ include "capsule-proxy.fullname" . }}-certgen
   labels:
     app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
     app.kubernetes.io/instance: {{ .Release.Name | quote }}
@@ -13,6 +14,7 @@ spec:
   template:
     metadata:
       name: "{{ .Release.Name }}-certgen"
+      name: {{ include "capsule-proxy.fullname" . }}-certgen
       labels:
         app.kubernetes.io/managed-by: {{ .Release.Service | quote }}
         app.kubernetes.io/instance: {{ .Release.Name | quote }}


### PR DESCRIPTION
The certgen-job did not respected the fullnameoverride.
Unified the labels with other resource labels in this process.