### PR TITLE
fix: imagePullSecrets belongs to spec instead of containers

### DIFF
--- a/charts/capsule-proxy/Chart.yaml
+++ b/charts/capsule-proxy/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.4.3
 description: Helm Chart for Capsule Proxy, addon for Capsule, the multi-tenant Operator
 name: capsule-proxy
 type: application
-version: 0.4.6
+version: 0.4.7
 home: https://github.com/clastix/capsule-proxy
 icon: https://github.com/clastix/capsule/raw/master/assets/logo/capsule_small.png
 keywords:

--- a/charts/capsule-proxy/templates/certgen-job.yaml
+++ b/charts/capsule-proxy/templates/certgen-job.yaml
@@ -22,10 +22,6 @@ spec:
       - name: post-install-job
         image: {{ include "capsule.jobs.certsFullyQualifiedDockerImage" $ }}
         imagePullPolicy: {{ .Values.jobs.certs.pullPolicy }}
-        {{- with $.Values.imagePullSecrets }}
-        imagePullSecrets:
-          {{- toYaml . | nindent 10 }}
-        {{- end }}
         args:
             - create
             - --host={{ include "capsule-proxy.certJob.SAN" . }}
@@ -42,5 +38,9 @@ spec:
         securityContext:
           {{- toYaml . | nindent 10 }}
         {{- end }}
+      {{- with $.Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}        
       serviceAccountName: {{ include "capsule-proxy.serviceAccountName" . }}
 {{- end }}


### PR DESCRIPTION
imagePullSecrets were misplaced under containers instead directly under spec. This PR will fix this.