### PR TITLE
fix(helm): add client side rate limiters

### DIFF
--- a/charts/capsule-proxy/Chart.yaml
+++ b/charts/capsule-proxy/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.4.4
 description: Helm Chart for Capsule Proxy, addon for Capsule, the multi-tenant Operator
 name: capsule-proxy
 type: application
-version: 0.4.8
+version: 0.4.9
 home: https://github.com/clastix/capsule-proxy
 icon: https://github.com/clastix/capsule/raw/master/assets/logo/capsule_small.png
 keywords:

--- a/charts/capsule-proxy/templates/_pod.tpl
+++ b/charts/capsule-proxy/templates/_pod.tpl
@@ -56,6 +56,8 @@ spec:
     - --ssl-cert-path={{ .Values.options.SSLDirectory }}/{{ .Values.options.SSLCertFileName }}
     - --ssl-key-path={{ .Values.options.SSLDirectory }}/{{ .Values.options.SSLKeyFileName }}
     {{- end }}
+    - --client-connection-qps={{ .Values.options.clientConnectionQPS }}
+    - --client-connection-burst={{ .Values.options.clientConnectionBurst }}
     ports:
     - name: proxy
       protocol: TCP


### PR DESCRIPTION
This is to add client side rate limiters in the helm manifests

Changes with code are already merged in the following PR's and released with v0.4.4.
https://github.com/clastix/capsule-proxy/pull/300
https://github.com/clastix/capsule-proxy/pull/301