### PR TITLE
feat(helm): add annotations for certgen job and make ttlSecondsAfterFinished optional

### DIFF
--- a/charts/capsule-proxy/Chart.yaml
+++ b/charts/capsule-proxy/Chart.yaml
@@ -3,7 +3,7 @@ appVersion: 0.4.4
 description: Helm Chart for Capsule Proxy, addon for Capsule, the multi-tenant Operator
 name: capsule-proxy
 type: application
-version: 0.4.5
+version: 0.5.0
 home: https://github.com/clastix/capsule-proxy
 icon: https://github.com/clastix/capsule/raw/master/assets/logo/capsule_small.png
 keywords:

--- a/charts/capsule-proxy/README.md
+++ b/charts/capsule-proxy/README.md
@@ -72,11 +72,13 @@ If you only need to make minor customizations, you can specify them on the comma
 | image.repository | string | `"clastix/capsule-proxy"` | Set the image repository of the capsule-proxy. |
 | image.tag | string | `""` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | Configuration for `imagePullSecrets` so that you can use a private images registry. |
+| jobs.annotations | object | `{}` | Annotations to add to the certgen job. |
 | jobs.certs.pullPolicy | string | `"IfNotPresent"` | Set the image pull policy of the post install certgen job |
 | jobs.certs.repository | string | `"docker.io/jettech/kube-webhook-certgen"` | Set the image repository of the post install certgen job |
 | jobs.certs.tag | string | `"v1.3.0"` | Set the image tag of the post install certgen job |
 | jobs.podSecurityContext | object | `{"seccompProfile":{"type":"RuntimeDefault"}}` | Security context for the job pods. |
 | jobs.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":1002,"runAsNonRoot":true,"runAsUser":1002}` | Security context for the job containers. |
+| jobs.ttlSecondsAfterFinished | int | `60` | Sets the ttl in seconds after a finished certgen job is deleted. Set to -1 to never delete. |
 | kind | string | `"Deployment"` | Set the deployment mode of the capsule-proxy as `Deployment` or `DaemonSet`. |
 | nodeSelector | object | `{}` | Set the node selector for the capsule-proxy pod. |
 | podAnnotations | object | `{}` | Annotations to add to the capsule-proxy pod. |

--- a/charts/capsule-proxy/templates/certgen-job.yaml
+++ b/charts/capsule-proxy/templates/certgen-job.yaml
@@ -5,8 +5,14 @@ metadata:
   name: {{ include "capsule-proxy.fullname" . }}-certgen
   labels:
     {{- include "capsule-proxy.labels" . | nindent 4 }}
+  {{- with .Values.jobs.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
-  ttlSecondsAfterFinished: 60
+  {{- if ge .Values.jobs.ttlSecondsAfterFinished 0.0 }}
+  ttlSecondsAfterFinished: {{ .Values.jobs.ttlSecondsAfterFinished }}
+  {{- end }}
   template:
     metadata:
       name: {{ include "capsule-proxy.fullname" . }}-certgen

--- a/charts/capsule-proxy/values.yaml
+++ b/charts/capsule-proxy/values.yaml
@@ -20,6 +20,12 @@ jobs:
     # -- Set the image tag of the post install certgen job
     tag: "v1.3.0"
 
+  # -- Annotations to add to the certgen job.
+  annotations: {}
+
+  # -- Sets the ttl in seconds after a finished certgen job is deleted. Set to -1 to never delete.
+  ttlSecondsAfterFinished: 60
+
   # -- Security context for the job pods.
   podSecurityContext:
     seccompProfile:


### PR DESCRIPTION
This is needed if capsule-proxy is rolled out with ArgoCD, see: https://argo-cd.readthedocs.io/en/stable/user-guide/resource_hooks/#hook-deletion-policies